### PR TITLE
Add support for EPM publication

### DIFF
--- a/Token_Contracts/ethpm.json
+++ b/Token_Contracts/ethpm.json
@@ -1,0 +1,13 @@
+{
+  "package_name": "tokens",
+  "version": "0.0.1",
+  "description": "Ethereum Token Contracts",
+  "authors": [
+    "Simon de la Rouviere <simon.delarouviere@consensys.net>"
+  ],
+  "keywords": [
+    "tokens",
+    "consensys"
+  ],
+  "license": "MIT"
+}

--- a/Token_Contracts/package.json
+++ b/Token_Contracts/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "erc20-tokens",
+  "version": "0.0.1",
+  "description": "Ethereum Token Contracts",
+  "main": "truffle.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "truffle test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ConsenSys/Tokens.git"
+  },
+  "keywords": [
+    "ethereum"
+  ],
+  "author": "Simon de la Rouviere <simon.delarouviere@consensys.net>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ConsenSys/Tokens/issues"
+  },
+  "homepage": "https://github.com/ConsenSys/Tokens#readme",
+  "dependencies": {
+    "truffle-hdwallet-provider": "0.0.3"
+  }
+}

--- a/Token_Contracts/truffle.js
+++ b/Token_Contracts/truffle.js
@@ -1,10 +1,25 @@
+const HDWalletProvider = require("truffle-hdwallet-provider")
+const fs = require("fs")
+
+// First read in the secrets.json to get our mnemonic
+let secrets
+let mnemonic
+if(fs.existsSync("secrets.json")) {
+  secrets = JSON.parse(fs.readFileSync("secrets.json", "utf8"))
+  mnemonic = secrets.mnemonic
+} else {
+  console.log("No secrets.json found. If you are trying to publish EPM " +
+              "this will fail. Otherwise, you can ignore this message!")
+  mnemonic = "" 
+}
+
 module.exports = {
   rpc: {
     host: "localhost",
     port: 8545
   },
   networks: {
-    "live": {
+    live: {
       network_id: 1, // Ethereum public network
       // optional config values
       // host - defaults to "localhost"
@@ -13,14 +28,18 @@ module.exports = {
       // gasPrice
       // from - default address to use for any transaction Truffle makes during migrations
     },
-    "morden": {
+    morden: {
       network_id: 2,
       host: "https://morden.infura.io",
     },
-    "testrpc": {
+    ropsten: {
+      provider: new HDWalletProvider(mnemonic, "https://ropsten.infura.io"),
+      network_id: "3"
+    },
+    testrpc: {
       network_id: "default"
     },
-    "test": { //truffle test hardcodes the "test" network.
+    test: { //truffle test hardcodes the "test" network.
       network_id: "default",
     }
   }


### PR DESCRIPTION
This commit modifies `truffle.js` to detect a `secrets.json` and, if one
exists, instantiate an hdwallet provider capable of deploying an EPM
package to the Ropsten testnet. The `secrets.json` file should look like:

```
{
  "mnemonic": "igor cannot dunk ..."
}
```

Important to note, [there is an upstream bug in Truffle](https://github.com/ConsenSys/truffle/issues/354) at the time of
this commit which causes EPM deployment to fail when it detects multiple
networks specified in the `truffle.js` file. Until this is fixed, to
deploy to EPM you will need to comment out all the networks other than Ropsten
before running `truffle publish`.