### PR TITLE
Fix extraData in approveAndCall not being ABI encoded in HumanStandardToken

### DIFF
--- a/Token_Contracts/test/humanStandardToken.js
+++ b/Token_Contracts/test/humanStandardToken.js
@@ -126,6 +126,9 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.allowance.call(accounts[0], sampleCtr.address);
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 100);
+            return sampleCtr.extraData.call();
+        }).then(function (result) {
+            assert.strictEqual(result, '0x42');
             return sampleCtr.value.call();
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 100);


### PR DESCRIPTION
Appending a bytes array to a function call wasn't properly setting it as the bytes parameter.