### PR TITLE
Repair test suite

### DIFF
--- a/Token_Contracts/contracts/Migrations.sol
+++ b/Token_Contracts/contracts/Migrations.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.4.4;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function Migrations() {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}
+

--- a/Token_Contracts/migrations/1_initial_migration.js
+++ b/Token_Contracts/migrations/1_initial_migration.js
@@ -1,0 +1,6 @@
+const Migrations = artifacts.require(`./Migrations.sol`);
+
+module.exports = (deployer) => {
+    deployer.deploy(Migrations);
+};
+

--- a/Token_Contracts/migrations/2_deploy_tokens.js
+++ b/Token_Contracts/migrations/2_deploy_tokens.js
@@ -1,0 +1,6 @@
+const HumanStandardToken = artifacts.require(`./HumanStandardToken.sol`);
+
+module.exports = (deployer) => {
+  deployer.deploy(HumanStandardToken);
+};
+

--- a/Token_Contracts/migrations/3_deploy_factory.js
+++ b/Token_Contracts/migrations/3_deploy_factory.js
@@ -1,0 +1,7 @@
+const HumanStandardTokenFactory =
+  artifacts.require(`./HumanStandardTokenFactory.sol`);
+
+module.exports = (deployer) => {
+  deployer.deploy(HumanStandardTokenFactory);
+};
+

--- a/Token_Contracts/test/humanStandardToken.js
+++ b/Token_Contracts/test/humanStandardToken.js
@@ -5,16 +5,15 @@ contract("HumanStandardToken", function(accounts) {
 
 //CREATION
 
-    it("creation: should create an initial balance of 10000 for the creator", function(done) {
+    it("creation: should create an initial balance of 10000 for the creator", function() {
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(ctr) {
             return ctr.balanceOf.call(accounts[0]);
-    }).then(function (result) {
-        assert.strictEqual(result.toNumber(), 10000);
-        done();
-        }).catch(done);
+        }).then(function (result) {
+            assert.strictEqual(result.toNumber(), 10000);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("creation: test correct setting of vanity information", function(done) {
+    it("creation: test correct setting of vanity information", function() {
       var ctr;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -27,19 +26,17 @@ contract("HumanStandardToken", function(accounts) {
         return ctr.symbol.call();
     }).then(function(result) {
         assert.strictEqual(result, 'SBX');
-        done();
-        }).catch(done);
+    }).catch((err) => { throw new Error(err); });
     });
 
-    it("creation: should succeed in creating over 2^256 - 1 (max) tokens", function(done) {
+    it("creation: should succeed in creating over 2^256 - 1 (max) tokens", function() {
         //2^256 - 1
         HumanStandardToken.new('115792089237316195423570985008687907853269984665640564039457584007913129639935', 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(ctr) {
             return ctr.totalSupply();
     }).then(function (result) {
         var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77');
         assert.isTrue(match);
-        done();
-        }).catch(done);
+    }).catch((err) => { throw new Error(err); });
     });
 
 //TRANSERS
@@ -48,18 +45,18 @@ contract("HumanStandardToken", function(accounts) {
     //this is not *good* enough as the contract could still throw an error otherwise.
     //ideally one should check balances before and after, but estimateGas currently always throws an error.
     //it's not giving estimate on gas used in the event of an error.
-    it("transfers: ether transfer should be reversed.", function(done) {
+    it("transfers: ether transfer should be reversed.", function() {
         var ctr;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return web3.eth.sendTransaction({from: accounts[0], to: ctr.address, value: web3.toWei("10", "Ether")});
         }).catch(function(result) {
-            done();
-        }).catch(done);
+            assert(true);
+        }).catch((err) => { throw new Error(err); });
     });
 
 
-    it("transfers: should transfer 10000 to accounts[1] with accounts[0] having 10000", function(done) {
+    it("transfers: should transfer 10000 to accounts[1] with accounts[0] having 10000", function() {
         var ctr;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -68,30 +65,27 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.balanceOf.call(accounts[1]);
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 10000);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("transfers: should fail when trying to transfer 10001 to accounts[1] with accounts[0] having 10000", function(done) {
+    it("transfers: should fail when trying to transfer 10001 to accounts[1] with accounts[0] having 10000", function() {
         var ctr;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transfer.call(accounts[1], 10001, {from: accounts[0]});
         }).then(function (result) {
             assert.isFalse(result);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("transfers: should fail when trying to transfer zero.", function(done) {
+    it("transfers: should fail when trying to transfer zero.", function() {
         var ctr;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transfer.call(accounts[1], 0, {from: accounts[0]});
         }).then(function (result) {
             assert.isFalse(result);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
     //NOTE: testing uint256 wrapping is impossible in this standard token since you can't supply > 2^256 -1.
@@ -100,7 +94,7 @@ contract("HumanStandardToken", function(accounts) {
 
 //APPROVALS
 
-    it("approvals: msg.sender should approve 100 to accounts[1]", function(done) {
+    it("approvals: msg.sender should approve 100 to accounts[1]", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -109,11 +103,10 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.allowance.call(accounts[0], accounts[1]);
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 100);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient. It should succeed.", function(done) {
+    it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient. It should succeed.", function() {
         var ctr = null;
         var sampleCtr = null
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
@@ -129,11 +122,10 @@ contract("HumanStandardToken", function(accounts) {
             return sampleCtr.value.call();
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 100);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient and throw.", function(done) {
+    it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient and throw.", function() {
         var ctr = null;
         var sampleCtr = null
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
@@ -144,12 +136,12 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.approveAndCall.call(sampleCtr.address, 100, '0x42', {from: accounts[0]});
         }).catch(function (result) {
             //It will catch OOG.
-            done();
-        }).catch(done)
+            assert(true);
+        })
     });
 
     //bit overkill. But is for testing a bug
-    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 once.", function(done) {
+    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 once.", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -177,12 +169,11 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.balanceOf.call(accounts[0]);
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 9980);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
     //should approve 100 of msg.sender & withdraw 50, twice. (should succeed)
-    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 twice.", function(done) {
+    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 twice.", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -215,12 +206,11 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.balanceOf.call(accounts[0]);
         }).then(function (result) {
             assert.strictEqual(result.toNumber(), 9960);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
     //should approve 100 of msg.sender & withdraw 50 & 60 (should fail).
-    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 50 & 60 (2nd tx should fail)", function(done) {
+    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 50 & 60 (2nd tx should fail)", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -245,22 +235,20 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]});
         }).then(function (result) {
             assert.isFalse(result);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("approvals: attempt withdrawal from acconut with no allowance (should fail)", function(done) {
+    it("approvals: attempt withdrawal from acconut with no allowance (should fail)", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]});
         }).then(function (result) {
               assert.isFalse(result);
-              done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("approvals: allow accounts[1] 100 to withdraw from accounts[0]. Withdraw 60 and then approve 0 & attempt transfer.", function(done) {
+    it("approvals: allow accounts[1] 100 to withdraw from accounts[0]. Withdraw 60 and then approve 0 & attempt transfer.", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -273,11 +261,10 @@ contract("HumanStandardToken", function(accounts) {
             return ctr.transferFrom.call(accounts[0], accounts[2], 10, {from: accounts[1]});
         }).then(function (result) {
               assert.isFalse(result);
-              done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
-    it("approvals: approve max (2^256 - 1)", function(done) {
+    it("approvals: approve max (2^256 - 1)", function() {
         var ctr = null;
         HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
@@ -287,8 +274,8 @@ contract("HumanStandardToken", function(accounts) {
         }).then(function (result) {
             var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77');
             assert.isTrue(match);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 
 });
+

--- a/Token_Contracts/test/humanStandardToken.js
+++ b/Token_Contracts/test/humanStandardToken.js
@@ -14,8 +14,8 @@ contract("HumanStandardToken", function(accounts) {
     });
 
     it("creation: test correct setting of vanity information", function() {
-      var ctr;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        var ctr;
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.name.call();
     }).then(function (result) {
@@ -31,7 +31,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("creation: should succeed in creating over 2^256 - 1 (max) tokens", function() {
         //2^256 - 1
-        HumanStandardToken.new('115792089237316195423570985008687907853269984665640564039457584007913129639935', 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(ctr) {
+        return HumanStandardToken.new('115792089237316195423570985008687907853269984665640564039457584007913129639935', 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(ctr) {
             return ctr.totalSupply();
     }).then(function (result) {
         var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77');
@@ -47,7 +47,7 @@ contract("HumanStandardToken", function(accounts) {
     //it's not giving estimate on gas used in the event of an error.
     it("transfers: ether transfer should be reversed.", function() {
         var ctr;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return web3.eth.sendTransaction({from: accounts[0], to: ctr.address, value: web3.toWei("10", "Ether")});
         }).catch(function(result) {
@@ -58,7 +58,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("transfers: should transfer 10000 to accounts[1] with accounts[0] having 10000", function() {
         var ctr;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transfer(accounts[1], 10000, {from: accounts[0]});
         }).then(function (result) {
@@ -70,7 +70,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("transfers: should fail when trying to transfer 10001 to accounts[1] with accounts[0] having 10000", function() {
         var ctr;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transfer.call(accounts[1], 10001, {from: accounts[0]});
         }).then(function (result) {
@@ -80,7 +80,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("transfers: should fail when trying to transfer zero.", function() {
         var ctr;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transfer.call(accounts[1], 0, {from: accounts[0]});
         }).then(function (result) {
@@ -96,7 +96,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("approvals: msg.sender should approve 100 to accounts[1]", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.approve(accounts[1], 100, {from: accounts[0]});
         }).then(function (result) {
@@ -109,7 +109,7 @@ contract("HumanStandardToken", function(accounts) {
     it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient. It should succeed.", function() {
         var ctr = null;
         var sampleCtr = null
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return SampleRecipientSuccess.new({from: accounts[0]});
         }).then(function(result) {
@@ -128,7 +128,7 @@ contract("HumanStandardToken", function(accounts) {
     it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient and throw.", function() {
         var ctr = null;
         var sampleCtr = null
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return SampleRecipientThrow.new({from: accounts[0]});
         }).then(function(result) {
@@ -143,7 +143,7 @@ contract("HumanStandardToken", function(accounts) {
     //bit overkill. But is for testing a bug
     it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 once.", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.balanceOf.call(accounts[0]);
         }).then(function (result) {
@@ -175,7 +175,7 @@ contract("HumanStandardToken", function(accounts) {
     //should approve 100 of msg.sender & withdraw 50, twice. (should succeed)
     it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 twice.", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.approve(accounts[1], 100, {from: accounts[0]});
         }).then(function (result) {
@@ -212,7 +212,7 @@ contract("HumanStandardToken", function(accounts) {
     //should approve 100 of msg.sender & withdraw 50 & 60 (should fail).
     it("approvals: msg.sender approves accounts[1] of 100 & withdraws 50 & 60 (2nd tx should fail)", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.approve(accounts[1], 100, {from: accounts[0]});
         }).then(function (result) {
@@ -240,7 +240,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("approvals: attempt withdrawal from acconut with no allowance (should fail)", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]});
         }).then(function (result) {
@@ -250,7 +250,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("approvals: allow accounts[1] 100 to withdraw from accounts[0]. Withdraw 60 and then approve 0 & attempt transfer.", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.approve(accounts[1], 100, {from: accounts[0]});
         }).then(function (result) {
@@ -266,7 +266,7 @@ contract("HumanStandardToken", function(accounts) {
 
     it("approvals: approve max (2^256 - 1)", function() {
         var ctr = null;
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
+        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
             ctr = result;
             return ctr.approve(accounts[1],'115792089237316195423570985008687907853269984665640564039457584007913129639935' , {from: accounts[0]});
         }).then(function (result) {

--- a/Token_Contracts/test/humanStandardTokenFactory.js
+++ b/Token_Contracts/test/humanStandardTokenFactory.js
@@ -7,19 +7,22 @@ contract("HumanStandardTokenFactory", function(accounts) {
     it("Verify a Human Standard Token once deployed using both verification functions.", function() {
         var factory = null;
         var newTokenAddr = null;
-        HumanStandardTokenFactory.new().then(function(ctr) {
-        factory = ctr;
-
-        return factory.createHumanStandardToken.call(100000, "Simon Bucks", 2, "SBX", {from: accounts[0]});
+        return HumanStandardTokenFactory.new().then(function(ctr) {
+            factory = ctr;
+            return factory.createHumanStandardToken.call(100000, "Simon Bucks", 2, "SBX", {from: accounts[0]});
         }).then(function(tokenContractAddr) {
+            console.log(`FINAL ASSERT`);
             newTokenAddr = tokenContractAddr;
             return factory.createHumanStandardToken(100000, "Simon Bucks", 2, "SBX", {from: accounts[0]});
         }).then(function(result) {
+            console.log(`FINAL ASSERT`);
             return factory.verifyHumanStandardToken.call(newTokenAddr, {from: accounts[0]});
         }).then(function (result) {
+            console.log(`FINAL ASSERT`);
             assert.strictEqual(result, true);
             return factory.isHumanToken.call(newTokenAddr, {from: accounts[0]});
         }).then(function (result) {
+            console.log(`FINAL ASSERT`);
             assert.strictEqual(result, true);
         }).catch((err) => { throw new Error(err); });
     });

--- a/Token_Contracts/test/humanStandardTokenFactory.js
+++ b/Token_Contracts/test/humanStandardTokenFactory.js
@@ -1,5 +1,3 @@
-//This currently throws a stack underflow, and thus commented out. Contract is correctly deployed, but createHumanStandardToken throws underflow.
-//Replicated under testrpc and debugging to fix this.
 var HumanStandardTokenFactory = artifacts.require("./HumanStandardTokenFactory.sol");
 
 contract("HumanStandardTokenFactory", function(accounts) {
@@ -11,19 +9,10 @@ contract("HumanStandardTokenFactory", function(accounts) {
             factory = ctr;
             return factory.createHumanStandardToken.call(100000, "Simon Bucks", 2, "SBX", {from: accounts[0]});
         }).then(function(tokenContractAddr) {
-            console.log(`FINAL ASSERT`);
             newTokenAddr = tokenContractAddr;
-            return factory.createHumanStandardToken(100000, "Simon Bucks", 2, "SBX", {from: accounts[0]});
-        }).then(function(result) {
-            console.log(`FINAL ASSERT`);
             return factory.verifyHumanStandardToken.call(newTokenAddr, {from: accounts[0]});
-        }).then(function (result) {
-            console.log(`FINAL ASSERT`);
-            assert.strictEqual(result, true);
-            return factory.isHumanToken.call(newTokenAddr, {from: accounts[0]});
-        }).then(function (result) {
-            console.log(`FINAL ASSERT`);
-            assert.strictEqual(result, true);
+        }).then(function(res) {
+            assert.strictEqual(res, true);
         }).catch((err) => { throw new Error(err); });
     });
 });

--- a/Token_Contracts/test/humanStandardTokenFactory.js
+++ b/Token_Contracts/test/humanStandardTokenFactory.js
@@ -4,7 +4,7 @@ var HumanStandardTokenFactory = artifacts.require("./HumanStandardTokenFactory.s
 
 contract("HumanStandardTokenFactory", function(accounts) {
 
-    it("Verify a Human Standard Token once deployed using both verification functions.", function(done) {
+    it("Verify a Human Standard Token once deployed using both verification functions.", function() {
         var factory = null;
         var newTokenAddr = null;
         HumanStandardTokenFactory.new().then(function(ctr) {
@@ -21,7 +21,7 @@ contract("HumanStandardTokenFactory", function(accounts) {
             return factory.isHumanToken.call(newTokenAddr, {from: accounts[0]});
         }).then(function (result) {
             assert.strictEqual(result, true);
-            done();
-        }).catch(done);
+        }).catch((err) => { throw new Error(err); });
     });
 });
+


### PR DESCRIPTION
The test suite in this repo had suffered some rather serious code rot, and didn't even run.

b4bb664 adds migrations such that the `truffle test` command can actually execute.

9c7db13 removes `done`s from tests returning promises, which were causing the tests to hang in any event because the promises weren't actually being returned (addressed in eb4d510).

eb4d510 returns the results of promise chains in tests that use code blocks, which because they were not being returned were causing all tests to appear to pass irrespective of their actual results.

88d3867 rationalizes the `humanStandardTokenFactory.js` test, removes duplicate code, dead code, fixes bugs, etc. The test actually fails, but fixing that Solidity is beyond the scope of this PR. At least there's something to test against now!