### PR TITLE
Add StandardJS linter

### DIFF
--- a/Token_Contracts/migrations/1_initial_migration.js
+++ b/Token_Contracts/migrations/1_initial_migration.js
@@ -1,6 +1,5 @@
-const Migrations = artifacts.require(`./Migrations.sol`);
+const Migrations = artifacts.require(`./Migrations.sol`)
 
 module.exports = (deployer) => {
-    deployer.deploy(Migrations);
-};
-
+  deployer.deploy(Migrations)
+}

--- a/Token_Contracts/migrations/2_deploy_tokens.js
+++ b/Token_Contracts/migrations/2_deploy_tokens.js
@@ -1,6 +1,5 @@
-const HumanStandardToken = artifacts.require(`./HumanStandardToken.sol`);
+const HumanStandardToken = artifacts.require(`./HumanStandardToken.sol`)
 
 module.exports = (deployer) => {
-  deployer.deploy(HumanStandardToken);
-};
-
+  deployer.deploy(HumanStandardToken)
+}

--- a/Token_Contracts/migrations/3_deploy_factory.js
+++ b/Token_Contracts/migrations/3_deploy_factory.js
@@ -1,7 +1,6 @@
 const HumanStandardTokenFactory =
-  artifacts.require(`./HumanStandardTokenFactory.sol`);
+  artifacts.require(`./HumanStandardTokenFactory.sol`)
 
 module.exports = (deployer) => {
-  deployer.deploy(HumanStandardTokenFactory);
-};
-
+  deployer.deploy(HumanStandardTokenFactory)
+}

--- a/Token_Contracts/package.json
+++ b/Token_Contracts/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "truffle test"
+    "test": "truffle test",
+    "lint": "standard --fix"
   },
   "repository": {
     "type": "git",
@@ -17,8 +18,8 @@
     "ethereum"
   ],
   "authors": [
-     "Simon de la Rouviere <simon.delarouviere@consensys.net>",
-     "Joseph Chow <joseph.chow@consensys.net>"
+    "Simon de la Rouviere <simon.delarouviere@consensys.net>",
+    "Joseph Chow <joseph.chow@consensys.net>"
   ],
   "license": "MIT",
   "bugs": {
@@ -27,5 +28,15 @@
   "homepage": "https://github.com/ConsenSys/Tokens#readme",
   "dependencies": {
     "truffle-hdwallet-provider": "0.0.3"
+  },
+  "devDependencies": {
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-node": "^5.1.0",
+    "eslint-plugin-react": "^7.1.0",
+    "eslint-plugin-standard": "^3.0.1",
+    "standard": "^10.0.2"
+  },
+  "standard": {
+    "globals": [ "assert", "it", "artifacts", "contract", "web3" ]
   }
 }

--- a/Token_Contracts/test/humanStandardToken.js
+++ b/Token_Contracts/test/humanStandardToken.js
@@ -1,281 +1,277 @@
-var HumanStandardToken = artifacts.require("./HumanStandardToken.sol");
-var SampleRecipientSuccess = artifacts.require("./SampleRecipientSuccess.sol");
+var HumanStandardToken = artifacts.require('./HumanStandardToken.sol')
+var SampleRecipientSuccess = artifacts.require('./SampleRecipientSuccess.sol')
 
-contract("HumanStandardToken", function(accounts) {
+contract('HumanStandardToken', function (accounts) {
+// CREATION
 
-//CREATION
-
-    it("creation: should create an initial balance of 10000 for the creator", function() {
-        HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(ctr) {
-            return ctr.balanceOf.call(accounts[0]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 10000);
-        }).catch((err) => { throw new Error(err); });
-    });
-
-    it("creation: test correct setting of vanity information", function() {
-        var ctr;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.name.call();
+  it('creation: should create an initial balance of 10000 for the creator', function () {
+    HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (ctr) {
+      return ctr.balanceOf.call(accounts[0])
     }).then(function (result) {
-        assert.strictEqual(result, 'Simon Bucks');
-        return ctr.decimals.call();
-    }).then(function(result) {
-        assert.strictEqual(result.toNumber(), 1);
-        return ctr.symbol.call();
-    }).then(function(result) {
-        assert.strictEqual(result, 'SBX');
-    }).catch((err) => { throw new Error(err); });
-    });
+      assert.strictEqual(result.toNumber(), 10000)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("creation: should succeed in creating over 2^256 - 1 (max) tokens", function() {
-        //2^256 - 1
-        return HumanStandardToken.new('115792089237316195423570985008687907853269984665640564039457584007913129639935', 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(ctr) {
-            return ctr.totalSupply();
+  it('creation: test correct setting of vanity information', function () {
+    var ctr
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.name.call()
     }).then(function (result) {
-        var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77');
-        assert.isTrue(match);
-    }).catch((err) => { throw new Error(err); });
-    });
+      assert.strictEqual(result, 'Simon Bucks')
+      return ctr.decimals.call()
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 1)
+      return ctr.symbol.call()
+    }).then(function (result) {
+      assert.strictEqual(result, 'SBX')
+    }).catch((err) => { throw new Error(err) })
+  })
 
-//TRANSERS
-//normal transfers without approvals.
+  it('creation: should succeed in creating over 2^256 - 1 (max) tokens', function () {
+        // 2^256 - 1
+    return HumanStandardToken.new('115792089237316195423570985008687907853269984665640564039457584007913129639935', 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (ctr) {
+      return ctr.totalSupply()
+    }).then(function (result) {
+      var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77')
+      assert.isTrue(match)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    //this is not *good* enough as the contract could still throw an error otherwise.
-    //ideally one should check balances before and after, but estimateGas currently always throws an error.
-    //it's not giving estimate on gas used in the event of an error.
-    it("transfers: ether transfer should be reversed.", function() {
-        var ctr;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return web3.eth.sendTransaction({from: accounts[0], to: ctr.address, value: web3.toWei("10", "Ether")});
-        }).catch(function(result) {
-            assert(true);
-        }).catch((err) => { throw new Error(err); });
-    });
+// TRANSERS
+// normal transfers without approvals.
 
+    // this is not *good* enough as the contract could still throw an error otherwise.
+    // ideally one should check balances before and after, but estimateGas currently always throws an error.
+    // it's not giving estimate on gas used in the event of an error.
+  it('transfers: ether transfer should be reversed.', function () {
+    var ctr
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return web3.eth.sendTransaction({from: accounts[0], to: ctr.address, value: web3.toWei('10', 'Ether')})
+    }).catch(function (result) {
+      assert(true)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("transfers: should transfer 10000 to accounts[1] with accounts[0] having 10000", function() {
-        var ctr;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.transfer(accounts[1], 10000, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.balanceOf.call(accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 10000);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('transfers: should transfer 10000 to accounts[1] with accounts[0] having 10000', function () {
+    var ctr
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.transfer(accounts[1], 10000, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.balanceOf.call(accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 10000)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("transfers: should fail when trying to transfer 10001 to accounts[1] with accounts[0] having 10000", function() {
-        var ctr;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.transfer.call(accounts[1], 10001, {from: accounts[0]});
-        }).then(function (result) {
-            assert.isFalse(result);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('transfers: should fail when trying to transfer 10001 to accounts[1] with accounts[0] having 10000', function () {
+    var ctr
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.transfer.call(accounts[1], 10001, {from: accounts[0]})
+    }).then(function (result) {
+      assert.isFalse(result)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("transfers: should fail when trying to transfer zero.", function() {
-        var ctr;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.transfer.call(accounts[1], 0, {from: accounts[0]});
-        }).then(function (result) {
-            assert.isFalse(result);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('transfers: should fail when trying to transfer zero.', function () {
+    var ctr
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.transfer.call(accounts[1], 0, {from: accounts[0]})
+    }).then(function (result) {
+      assert.isFalse(result)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    //NOTE: testing uint256 wrapping is impossible in this standard token since you can't supply > 2^256 -1.
+    // NOTE: testing uint256 wrapping is impossible in this standard token since you can't supply > 2^256 -1.
 
-    //todo: transfer max amounts.
+    // todo: transfer max amounts.
 
-//APPROVALS
+// APPROVALS
 
-    it("approvals: msg.sender should approve 100 to accounts[1]", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.approve(accounts[1], 100, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 100);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('approvals: msg.sender should approve 100 to accounts[1]', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.approve(accounts[1], 100, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 100)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient. It should succeed.", function() {
-        var ctr = null;
-        var sampleCtr = null
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return SampleRecipientSuccess.new({from: accounts[0]});
-        }).then(function(result) {
-            sampleCtr = result;
-            return ctr.approveAndCall(sampleCtr.address, 100, '0x42', {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], sampleCtr.address);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 100);
-            return sampleCtr.value.call();
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 100);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient. It should succeed.', function () {
+    var ctr = null
+    var sampleCtr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return SampleRecipientSuccess.new({from: accounts[0]})
+    }).then(function (result) {
+      sampleCtr = result
+      return ctr.approveAndCall(sampleCtr.address, 100, '0x42', {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], sampleCtr.address)
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 100)
+      return sampleCtr.value.call()
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 100)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient and throw.", function() {
-        var ctr = null;
-        var sampleCtr = null
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return SampleRecipientThrow.new({from: accounts[0]});
-        }).then(function(result) {
-            sampleCtr = result;
-            return ctr.approveAndCall.call(sampleCtr.address, 100, '0x42', {from: accounts[0]});
-        }).catch(function (result) {
-            //It will catch OOG.
-            assert(true);
-        })
-    });
+  it('approvals: msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient and throw.', function () {
+    var ctr = null
+    var sampleCtr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return SampleRecipientThrow.new({from: accounts[0]})
+    }).then(function (result) {
+      sampleCtr = result
+      return ctr.approveAndCall.call(sampleCtr.address, 100, '0x42', {from: accounts[0]})
+    }).catch(function (result) {
+            // It will catch OOG.
+      assert(true)
+    })
+  })
 
-    //bit overkill. But is for testing a bug
-    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 once.", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.balanceOf.call(accounts[0]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 10000);
-            return ctr.approve(accounts[1], 100, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.balanceOf.call(accounts[2]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 0);
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 100);
-            return ctr.transferFrom.call(accounts[0], accounts[2], 20, {from: accounts[1]});
-        }).then(function (result) {
-            return ctr.transferFrom(accounts[0], accounts[2], 20, {from: accounts[1]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 80);
-            return ctr.balanceOf.call(accounts[2]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 20);
-            return ctr.balanceOf.call(accounts[0]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 9980);
-        }).catch((err) => { throw new Error(err); });
-    });
+    // bit overkill. But is for testing a bug
+  it('approvals: msg.sender approves accounts[1] of 100 & withdraws 20 once.', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.balanceOf.call(accounts[0])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 10000)
+      return ctr.approve(accounts[1], 100, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.balanceOf.call(accounts[2])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 0)
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 100)
+      return ctr.transferFrom.call(accounts[0], accounts[2], 20, {from: accounts[1]})
+    }).then(function (result) {
+      return ctr.transferFrom(accounts[0], accounts[2], 20, {from: accounts[1]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 80)
+      return ctr.balanceOf.call(accounts[2])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 20)
+      return ctr.balanceOf.call(accounts[0])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 9980)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    //should approve 100 of msg.sender & withdraw 50, twice. (should succeed)
-    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 20 twice.", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.approve(accounts[1], 100, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 100);
-            return ctr.transferFrom(accounts[0], accounts[2], 20, {from: accounts[1]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 80);
-            return ctr.balanceOf.call(accounts[2]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 20);
-            return ctr.balanceOf.call(accounts[0]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 9980);
-            //FIRST tx done.
-            //onto next.
-            return ctr.transferFrom(accounts[0], accounts[2], 20, {from: accounts[1]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 60);
-            return ctr.balanceOf.call(accounts[2]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 40);
-            return ctr.balanceOf.call(accounts[0]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 9960);
-        }).catch((err) => { throw new Error(err); });
-    });
+    // should approve 100 of msg.sender & withdraw 50, twice. (should succeed)
+  it('approvals: msg.sender approves accounts[1] of 100 & withdraws 20 twice.', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.approve(accounts[1], 100, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 100)
+      return ctr.transferFrom(accounts[0], accounts[2], 20, {from: accounts[1]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 80)
+      return ctr.balanceOf.call(accounts[2])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 20)
+      return ctr.balanceOf.call(accounts[0])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 9980)
+            // FIRST tx done.
+            // onto next.
+      return ctr.transferFrom(accounts[0], accounts[2], 20, {from: accounts[1]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 60)
+      return ctr.balanceOf.call(accounts[2])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 40)
+      return ctr.balanceOf.call(accounts[0])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 9960)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    //should approve 100 of msg.sender & withdraw 50 & 60 (should fail).
-    it("approvals: msg.sender approves accounts[1] of 100 & withdraws 50 & 60 (2nd tx should fail)", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.approve(accounts[1], 100, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 100);
-            return ctr.transferFrom(accounts[0], accounts[2], 50, {from: accounts[1]});
-        }).then(function (result) {
-            return ctr.allowance.call(accounts[0], accounts[1]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 50);
-            return ctr.balanceOf.call(accounts[2]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 50);
-            return ctr.balanceOf.call(accounts[0]);
-        }).then(function (result) {
-            assert.strictEqual(result.toNumber(), 9950);
-            //FIRST tx done.
-            //onto next.
-            return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]});
-        }).then(function (result) {
-            assert.isFalse(result);
-        }).catch((err) => { throw new Error(err); });
-    });
+    // should approve 100 of msg.sender & withdraw 50 & 60 (should fail).
+  it('approvals: msg.sender approves accounts[1] of 100 & withdraws 50 & 60 (2nd tx should fail)', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.approve(accounts[1], 100, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 100)
+      return ctr.transferFrom(accounts[0], accounts[2], 50, {from: accounts[1]})
+    }).then(function (result) {
+      return ctr.allowance.call(accounts[0], accounts[1])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 50)
+      return ctr.balanceOf.call(accounts[2])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 50)
+      return ctr.balanceOf.call(accounts[0])
+    }).then(function (result) {
+      assert.strictEqual(result.toNumber(), 9950)
+            // FIRST tx done.
+            // onto next.
+      return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]})
+    }).then(function (result) {
+      assert.isFalse(result)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("approvals: attempt withdrawal from acconut with no allowance (should fail)", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]});
-        }).then(function (result) {
-              assert.isFalse(result);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('approvals: attempt withdrawal from acconut with no allowance (should fail)', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]})
+    }).then(function (result) {
+      assert.isFalse(result)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("approvals: allow accounts[1] 100 to withdraw from accounts[0]. Withdraw 60 and then approve 0 & attempt transfer.", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.approve(accounts[1], 100, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.transferFrom(accounts[0], accounts[2], 60, {from: accounts[1]});
-        }).then(function (result) {
-            return ctr.approve(accounts[1], 0, {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.transferFrom.call(accounts[0], accounts[2], 10, {from: accounts[1]});
-        }).then(function (result) {
-              assert.isFalse(result);
-        }).catch((err) => { throw new Error(err); });
-    });
+  it('approvals: allow accounts[1] 100 to withdraw from accounts[0]. Withdraw 60 and then approve 0 & attempt transfer.', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.approve(accounts[1], 100, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.transferFrom(accounts[0], accounts[2], 60, {from: accounts[1]})
+    }).then(function (result) {
+      return ctr.approve(accounts[1], 0, {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.transferFrom.call(accounts[0], accounts[2], 10, {from: accounts[1]})
+    }).then(function (result) {
+      assert.isFalse(result)
+    }).catch((err) => { throw new Error(err) })
+  })
 
-    it("approvals: approve max (2^256 - 1)", function() {
-        var ctr = null;
-        return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function(result) {
-            ctr = result;
-            return ctr.approve(accounts[1],'115792089237316195423570985008687907853269984665640564039457584007913129639935' , {from: accounts[0]});
-        }).then(function (result) {
-            return ctr.allowance(accounts[0], accounts[1]);
-        }).then(function (result) {
-            var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77');
-            assert.isTrue(match);
-        }).catch((err) => { throw new Error(err); });
-    });
-
-});
-
+  it('approvals: approve max (2^256 - 1)', function () {
+    var ctr = null
+    return HumanStandardToken.new(10000, 'Simon Bucks', 1, 'SBX', {from: accounts[0]}).then(function (result) {
+      ctr = result
+      return ctr.approve(accounts[1], '115792089237316195423570985008687907853269984665640564039457584007913129639935', {from: accounts[0]})
+    }).then(function (result) {
+      return ctr.allowance(accounts[0], accounts[1])
+    }).then(function (result) {
+      var match = result.equals('1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77')
+      assert.isTrue(match)
+    }).catch((err) => { throw new Error(err) })
+  })
+})

--- a/Token_Contracts/test/humanStandardTokenFactory.js
+++ b/Token_Contracts/test/humanStandardTokenFactory.js
@@ -1,19 +1,17 @@
-var HumanStandardTokenFactory = artifacts.require("./HumanStandardTokenFactory.sol");
+var HumanStandardTokenFactory = artifacts.require('./HumanStandardTokenFactory.sol')
 
-contract("HumanStandardTokenFactory", function(accounts) {
-
-    it("Verify a Human Standard Token once deployed using both verification functions.", function() {
-        var factory = null;
-        var newTokenAddr = null;
-        return HumanStandardTokenFactory.new().then(function(ctr) {
-            factory = ctr;
-            return factory.createHumanStandardToken.call(100000, "Simon Bucks", 2, "SBX", {from: accounts[0]});
-        }).then(function(tokenContractAddr) {
-            newTokenAddr = tokenContractAddr;
-            return factory.verifyHumanStandardToken.call(newTokenAddr, {from: accounts[0]});
-        }).then(function(res) {
-            assert.strictEqual(res, true);
-        }).catch((err) => { throw new Error(err); });
-    });
-});
-
+contract('HumanStandardTokenFactory', function (accounts) {
+  it('Verify a Human Standard Token once deployed using both verification functions.', function () {
+    var factory = null
+    var newTokenAddr = null
+    return HumanStandardTokenFactory.new().then(function (ctr) {
+      factory = ctr
+      return factory.createHumanStandardToken.call(100000, 'Simon Bucks', 2, 'SBX', {from: accounts[0]})
+    }).then(function (tokenContractAddr) {
+      newTokenAddr = tokenContractAddr
+      return factory.verifyHumanStandardToken.call(newTokenAddr, {from: accounts[0]})
+    }).then(function (res) {
+      assert.strictEqual(res, true)
+    }).catch((err) => { throw new Error(err) })
+  })
+})

--- a/Token_Contracts/test/tokenTester.js
+++ b/Token_Contracts/test/tokenTester.js
@@ -1,7 +1,7 @@
-//currently commented out as TokenTester is causing a OOG error due to the Factory being too big
-//Not fully needed as factory & separate tests cover token creation.
+// currently commented out as TokenTester is causing a OOG error due to the Factory being too big
+// Not fully needed as factory & separate tests cover token creation.
 
-/*contract("TokenTester", function(accounts) {
+/* contract("TokenTester", function(accounts) {
     it("creates 10000 initial tokens", function(done) {
         var tester = TokenTester.at(TokenTester.deployed_address);
         tester.tokenContractAddress.call()
@@ -15,4 +15,4 @@
     });
 
     //todo:add test on retrieving addresses
-});*/
+}); */

--- a/Token_Contracts/truffle.js
+++ b/Token_Contracts/truffle.js
@@ -1,22 +1,22 @@
-const HDWalletProvider = require("truffle-hdwallet-provider")
-const fs = require("fs")
+const HDWalletProvider = require('truffle-hdwallet-provider')
+const fs = require('fs')
 
 // First read in the secrets.json to get our mnemonic
 let secrets
 let mnemonic
-if(fs.existsSync("secrets.json")) {
-  secrets = JSON.parse(fs.readFileSync("secrets.json", "utf8"))
+if (fs.existsSync('secrets.json')) {
+  secrets = JSON.parse(fs.readFileSync('secrets.json', 'utf8'))
   mnemonic = secrets.mnemonic
 } else {
-  console.log("No secrets.json found. If you are trying to publish EPM " +
-              "this will fail. Otherwise, you can ignore this message!")
-  mnemonic = ""
+  console.log('No secrets.json found. If you are trying to publish EPM ' +
+              'this will fail. Otherwise, you can ignore this message!')
+  mnemonic = ''
 }
 
 module.exports = {
   networks: {
     live: {
-      network_id: 1, // Ethereum public network
+      network_id: 1 // Ethereum public network
       // optional config values
       // host - defaults to "localhost"
       // port - defaults to 8545
@@ -26,19 +26,19 @@ module.exports = {
     },
     morden: {
       network_id: 2,
-      host: "https://morden.infura.io",
+      host: 'https://morden.infura.io'
     },
     ropsten: {
-      provider: new HDWalletProvider(mnemonic, "https://ropsten.infura.io"),
-      network_id: "3"
+      provider: new HDWalletProvider(mnemonic, 'https://ropsten.infura.io'),
+      network_id: '3'
     },
     testrpc: {
-      network_id: "default"
+      network_id: 'default'
     },
-    development: { //truffle test hardcodes the "test" network.
-      host: "localhost",
-      port: "8545",
-      network_id: "default",
+    development: { // truffle test hardcodes the "test" network.
+      host: 'localhost',
+      port: '8545',
+      network_id: 'default'
     }
   }
-};
+}


### PR DESCRIPTION
The linter is standardjs, the same linter used by the ethereumjs
project. https://standardjs.com

You can run the linter in the repo with `npm run lint`.

This linter has already helped in discovering a bug.
`SampleRecipientThrow` in humanStandardToken.js is `undefined`!