### PR TITLE
Require missing artifact

### DIFF
--- a/Token_Contracts/test/humanStandardToken.js
+++ b/Token_Contracts/test/humanStandardToken.js
@@ -1,5 +1,6 @@
 var HumanStandardToken = artifacts.require('./HumanStandardToken.sol')
 var SampleRecipientSuccess = artifacts.require('./SampleRecipientSuccess.sol')
+var SampleRecipientThrow = artifacts.require('./SampleRecipientThrow.sol')
 
 contract('HumanStandardToken', function (accounts) {
 // CREATION


### PR DESCRIPTION
SampleRecipientThrow was `undefined`, so the `approvals` test for `msg.sender should approve 100 to SampleRecipient and then NOTIFY SampleRecipient and throw` was passing on the basis of catching a Javascript error (`SampleRecipientThrow undefined`) rather than an EVM error (`OOG`).