### PR TITLE
Change return falses and throws to reverts

### DIFF
--- a/Token_Contracts/contracts/HumanStandardToken.sol
+++ b/Token_Contracts/contracts/HumanStandardToken.sol
@@ -19,7 +19,7 @@ contract HumanStandardToken is StandardToken {
 
     function () {
         //if ether is sent to this address, send it back.
-        throw;
+        revert();
     }
 
     /* Public variables of the token */
@@ -56,7 +56,7 @@ contract HumanStandardToken is StandardToken {
         //call the receiveApproval function on the contract you want to be notified. This crafts the function signature manually so one doesn't have to include a contract in here just for this.
         //receiveApproval(address _from, uint256 _value, address _tokenContract, bytes _extraData)
         //it is assumed that when does this that the call *should* succeed, otherwise one would use vanilla approve instead.
-        if(!_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData)) { throw; }
+        if(!_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData)) { revert(); }
         return true;
     }
 }

--- a/Token_Contracts/contracts/HumanStandardToken.sol
+++ b/Token_Contracts/contracts/HumanStandardToken.sol
@@ -17,11 +17,6 @@ pragma solidity ^0.4.8;
 
 contract HumanStandardToken is StandardToken {
 
-    function () {
-        //if ether is sent to this address, send it back.
-        revert();
-    }
-
     /* Public variables of the token */
 
     /*

--- a/Token_Contracts/contracts/HumanStandardToken.sol
+++ b/Token_Contracts/contracts/HumanStandardToken.sol
@@ -56,7 +56,7 @@ contract HumanStandardToken is StandardToken {
         //call the receiveApproval function on the contract you want to be notified. This crafts the function signature manually so one doesn't have to include a contract in here just for this.
         //receiveApproval(address _from, uint256 _value, address _tokenContract, bytes _extraData)
         //it is assumed that when does this that the call *should* succeed, otherwise one would use vanilla approve instead.
-        if(!_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData)) { revert(); }
+        require(_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData));
         return true;
     }
 }

--- a/Token_Contracts/contracts/SampleRecipientThrow.sol
+++ b/Token_Contracts/contracts/SampleRecipientThrow.sol
@@ -5,7 +5,4 @@ This one will throw and thus needs to propagate the error up.
 pragma solidity ^0.4.8;
 
 contract SampleRecipientThrow {
-  function () {
-    revert();
-  }
 }

--- a/Token_Contracts/contracts/SampleRecipientThrow.sol
+++ b/Token_Contracts/contracts/SampleRecipientThrow.sol
@@ -6,6 +6,6 @@ pragma solidity ^0.4.8;
 
 contract SampleRecipientThrow {
   function () {
-    throw;
+    revert();
   }
 }

--- a/Token_Contracts/contracts/StandardToken.sol
+++ b/Token_Contracts/contracts/StandardToken.sol
@@ -16,25 +16,23 @@ contract StandardToken is Token {
         //Default assumes totalSupply can't be over max (2^256 - 1).
         //If your token leaves out totalSupply and can issue more tokens as time goes on, you need to check if it doesn't wrap.
         //Replace the if with this one instead.
-        //if (balances[msg.sender] >= _value && balances[_to] + _value > balances[_to]) {
-        if (balances[msg.sender] >= _value) {
-            balances[msg.sender] -= _value;
-            balances[_to] += _value;
-            Transfer(msg.sender, _to, _value);
-            return true;
-        } else { revert(); }
+        //require(balances[msg.sender] >= _value && balances[_to] + _value > balances[_to]);
+        require(balances[msg.sender] >= _value);
+        balances[msg.sender] -= _value;
+        balances[_to] += _value;
+        Transfer(msg.sender, _to, _value);
+        return true;
     }
 
     function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
         //same as above. Replace this line with the following if you want to protect against wrapping uints.
-        //if (balances[_from] >= _value && allowed[_from][msg.sender] >= _value && balances[_to] + _value > balances[_to]) {
-        if (balances[_from] >= _value && allowed[_from][msg.sender] >= _value) {
-            balances[_to] += _value;
-            balances[_from] -= _value;
-            allowed[_from][msg.sender] -= _value;
-            Transfer(_from, _to, _value);
-            return true;
-        } else { revert(); }
+        //require(balances[_from] >= _value && allowed[_from][msg.sender] >= _value && balances[_to] + _value > balances[_to]);
+        require(balances[_from] >= _value && allowed[_from][msg.sender] >= _value);
+        balances[_to] += _value;
+        balances[_from] -= _value;
+        allowed[_from][msg.sender] -= _value;
+        Transfer(_from, _to, _value);
+        return true;
     }
 
     function balanceOf(address _owner) constant returns (uint256 balance) {

--- a/Token_Contracts/contracts/StandardToken.sol
+++ b/Token_Contracts/contracts/StandardToken.sol
@@ -22,7 +22,7 @@ contract StandardToken is Token {
             balances[_to] += _value;
             Transfer(msg.sender, _to, _value);
             return true;
-        } else { return false; }
+        } else { revert(); }
     }
 
     function transferFrom(address _from, address _to, uint256 _value) returns (bool success) {
@@ -34,7 +34,7 @@ contract StandardToken is Token {
             allowed[_from][msg.sender] -= _value;
             Transfer(_from, _to, _value);
             return true;
-        } else { return false; }
+        } else { revert(); }
     }
 
     function balanceOf(address _owner) constant returns (uint256 balance) {

--- a/Token_Contracts/test/humanStandardToken.js
+++ b/Token_Contracts/test/humanStandardToken.js
@@ -3,6 +3,13 @@ var SampleRecipientSuccess = artifacts.require('./SampleRecipientSuccess.sol')
 var SampleRecipientThrow = artifacts.require('./SampleRecipientThrow.sol')
 
 contract('HumanStandardToken', function (accounts) {
+  const evmThrewError = (err) => {
+    if (err.toString().includes('VM Exception while executing eth_call: invalid opcode')) {
+      return true
+    }
+    return false
+  }
+
 // CREATION
 
   it('creation: should create an initial balance of 10000 for the creator', function () {
@@ -73,8 +80,11 @@ contract('HumanStandardToken', function (accounts) {
       ctr = result
       return ctr.transfer.call(accounts[1], 10001, {from: accounts[0]})
     }).then(function (result) {
-      assert.isFalse(result)
-    }).catch((err) => { throw new Error(err) })
+      assert(false, 'The preceding call should have thrown an error.')
+    }).catch((err) => {
+      assert(evmThrewError(err), 'the EVM did not throw an error or did not ' +
+                                 'throw the expected error')
+    })
   })
 
   it('transfers: should handle zero-transfers normally', function () {
@@ -233,8 +243,11 @@ contract('HumanStandardToken', function (accounts) {
             // onto next.
       return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]})
     }).then(function (result) {
-      assert.isFalse(result)
-    }).catch((err) => { throw new Error(err) })
+      assert(false, 'The preceding call should have thrown an error.')
+    }).catch((err) => {
+      assert(evmThrewError(err), 'the EVM did not throw an error or did not ' +
+                                 'throw the expected error')
+    })
   })
 
   it('approvals: attempt withdrawal from acconut with no allowance (should fail)', function () {
@@ -243,8 +256,11 @@ contract('HumanStandardToken', function (accounts) {
       ctr = result
       return ctr.transferFrom.call(accounts[0], accounts[2], 60, {from: accounts[1]})
     }).then(function (result) {
-      assert.isFalse(result)
-    }).catch((err) => { throw new Error(err) })
+      assert(false, 'The preceding call should have thrown an error.')
+    }).catch((err) => {
+      assert(evmThrewError(err), 'the EVM did not throw an error or did not ' +
+                                 'throw the expected error')
+    })
   })
 
   it('approvals: allow accounts[1] 100 to withdraw from accounts[0]. Withdraw 60 and then approve 0 & attempt transfer.', function () {
@@ -259,8 +275,11 @@ contract('HumanStandardToken', function (accounts) {
     }).then(function (result) {
       return ctr.transferFrom.call(accounts[0], accounts[2], 10, {from: accounts[1]})
     }).then(function (result) {
-      assert.isFalse(result)
-    }).catch((err) => { throw new Error(err) })
+      assert(false, 'The preceding call should have thrown an error.')
+    }).catch((err) => {
+      assert(evmThrewError(err), 'the EVM did not throw an error or did not ' +
+                                 'throw the expected error')
+    })
   })
 
   it('approvals: approve max (2^256 - 1)', function () {


### PR DESCRIPTION
1. `throw` is deprecated in Solidity, so I changed all the `throw`s to `revert`s.
2. EIP610 says we should `throw` on failure instead of returning `false`, so I replaced all the `return false`s with `revert`s.

I also updated the tests accordingly.

Resolves #61.