### PR TITLE
slightly cheaper approveAndCall

### DIFF
--- a/contracts/HumanStandardToken.sol
+++ b/contracts/HumanStandardToken.sol
@@ -16,6 +16,8 @@ import "./StandardToken.sol";
 pragma solidity ^0.4.8;
 
 contract HumanStandardToken is StandardToken {
+    /* Constants */
+    bytes4 public constant RECEIVE_APPROVAL_SIGNATURE = bytes4(bytes32(keccak256("receiveApproval(address,uint256,address,bytes)")));
 
     /* Public variables of the token */
 
@@ -45,13 +47,13 @@ contract HumanStandardToken is StandardToken {
 
     /* Approves and then calls the receiving contract */
     function approveAndCall(address _spender, uint256 _value, bytes _extraData) returns (bool success) {
-        allowed[msg.sender][_spender] = _value;
-        Approval(msg.sender, _spender, _value);
+        // must successfully approve
+        require(approve(_spender, _value));
 
         //call the receiveApproval function on the contract you want to be notified. This crafts the function signature manually so one doesn't have to include a contract in here just for this.
         //receiveApproval(address _from, uint256 _value, address _tokenContract, bytes _extraData)
         //it is assumed when one does this that the call *should* succeed, otherwise one would use vanilla approve instead.
-        require(_spender.call(bytes4(bytes32(sha3("receiveApproval(address,uint256,address,bytes)"))), msg.sender, _value, this, _extraData));
+        require(_spender.call(RECEIVE_APPROVAL_SIGNATURE, msg.sender, _value, this, _extraData));
         return true;
     }
 }


### PR DESCRIPTION
* use the approve method of the parent contract `StandardToken`
* move the signature calculation into a constant computed at compile time