### PR TITLE
Add inline publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "compile": "truffle compile",
     "test": "standard && truffle test",
-    "lint": "standard --fix"
+    "lint": "standard --fix",
+    "publish": "truffle publish"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add a publish script to the `package.json` to ensure the Truffle/solc version used to publish is the same as that tested against.