### PR TITLE
Do not automatically fix when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "compile": "truffle compile",
-    "lint:js": "eslint --fix test/**/*.js migrations/**/*.js",
+    "fix:js": "eslint --fix test/**/*.js migrations/**/*.js",
+    "lint:js": "eslint test/**/*.js migrations/**/*.js",
     "lint:sol": "solhint contracts/*.sol contracts/*/*.sol test/*.sol test/*/*.sol",
     "lint": "npm run lint:js && npm run lint:sol",
     "publish": "truffle publish",


### PR DESCRIPTION
We require linting to be correct to pass tests. The way `eslint` works, if you have unlinted code that is fixable, and you run `eslint --fix`, it won't emit any errors. This means that someone can commit code to this repo which is not properly linted, but which passes the tests because `eslint` _can_ fix it (and does at runtime). Of course these runtime fixes are not actually persisted back to the commit which was included.

All this PR does is change the lint:js lint command to not fix, and adds a `fix:js` command which does fix. This means it's still easy to auto-fix unlinted js, but prevents that same unlinted js from passing tests.