### PR TITLE
Update truffle and tests to error on Revert

### DIFF
--- a/contracts/eip20/EIP20.sol
+++ b/contracts/eip20/EIP20.sol
@@ -1,5 +1,5 @@
 /*
-Implements EIP20 token standard: https://github.com/ethereum/EIPs/issues/20
+Implements EIP20 token standard: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
 .*/
 
 

--- a/migrations/2_deploy_tokens.js
+++ b/migrations/2_deploy_tokens.js
@@ -1,5 +1,5 @@
 const EIP20 = artifacts.require('./EIP20.sol');
 
 module.exports = (deployer) => {
-  deployer.deploy(EIP20);
+  deployer.deploy(EIP20, 10000, 'Simon Bucks', 1, 'SBX');
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4412,13 +4412,27 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.0.1.tgz",
-      "integrity": "sha512-PybO+GMq3AvsfCWfEx4sbuaJlDL19iR8Ff20cO0TtP599N5JbMLlhwlffvVInPgFjP+F11vjSOYj3hT8fONs5A==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.0.6.tgz",
+      "integrity": "sha512-E4u1dZr2IGY4liulO/nGMtavx4jVLXIJp48lxFq54N+gMRGhmBQp5kf1etA3bYhHVtO9IO76qRiHMMVuId7cRg==",
       "requires": {
         "mocha": "3.5.3",
         "original-require": "1.0.1",
-        "solc": "0.4.18"
+        "solc": "0.4.19"
+      },
+      "dependencies": {
+        "solc": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.19.tgz",
+          "integrity": "sha512-hvi/vi9rQcB73poRLoLRfQIYKwmdhrNbZlOOFCGd5v58gEsYEUr3+oHPSXhyk4CFNchWC2ojpMYrHDJNm0h4jQ==",
+          "requires": {
+            "fs-extra": "0.30.0",
+            "memorystream": "0.3.1",
+            "require-from-string": "1.2.1",
+            "semver": "5.4.1",
+            "yargs": "4.8.1"
+          }
+        }
       }
     },
     "truffle-hdwallet-provider": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "compile": "truffle compile",
-    "fix:js": "eslint --fix test/**/*.js migrations/**/*.js",
-    "lint:js": "eslint test/**/*.js migrations/**/*.js",
+    "fix:js": "eslint --fix test/**/*.js test/*.js migrations/*.js",
+    "lint:js": "eslint test/**/*.js test/*.js migrations/*.js",
     "lint:sol": "solhint contracts/*.sol contracts/*/*.sol test/*.sol test/*/*.sol",
     "lint": "npm run lint:js && npm run lint:sol",
     "publish": "truffle publish",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/ConsenSys/Tokens#readme",
   "dependencies": {
-    "truffle": "4.0.5",
+    "truffle": "4.0.6",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "compile": "truffle compile",
-    "fix:js": "eslint --fix test/**/*.js test/*.js migrations/*.js",
-    "lint:js": "eslint test/**/*.js test/*.js migrations/*.js",
+    "fix:js": "eslint --fix test/** migrations/**",
+    "lint:js": "eslint test/** migrations/**",
     "lint:sol": "solhint contracts/*.sol contracts/*/*.sol test/*.sol test/*/*.sol",
     "lint": "npm run lint:js && npm run lint:sol",
     "publish": "truffle publish",

--- a/test/helpers/assertRevert.js
+++ b/test/helpers/assertRevert.js
@@ -2,10 +2,11 @@ module.exports = {
   assertRevert: async (promise) => {
     try {
       await promise;
-      assert.fail('Expected revert not received');
     } catch (error) {
       const revertFound = error.message.search('revert') >= 0;
       assert(revertFound, `Expected "revert", got ${error} instead`);
+      return;
     }
+    assert.fail('Expected revert not received');
   },
 };


### PR DESCRIPTION
I upgraded truffle to 4.0.6 to get the proper `revert` message. 

This is a pre-req for integrating solidity-coverage.