### PR TITLE
Fix #119: verifyEIP20 broken in EIP20Factory.sol

### DIFF
--- a/contracts/eip20/EIP20Factory.sol
+++ b/contracts/eip20/EIP20Factory.sol
@@ -29,8 +29,8 @@ contract EIP20Factory {
             if (fetchedTokenByteCode[i] != EIP20ByteCode[i]) {
                 return false;
             }
-            return true;
         }
+        return true;
     }
     
     function createEIP20(uint256 _initialAmount, string _name, uint8 _decimals, string _symbol) 


### PR DESCRIPTION
The verifyEIP20 function does two checks to assert whether the code at a given address is known EIP20 code. In the first check, it simply compares the length (in bytes) of the code at the provided address to the length of the known EIP20 code. If that check passes, it would then iterate though the code at the provided address byte by byte and compare each byte to the known EIP20 code, returning false if any byte did not match.

In a run of the linter initially committed at a7837478bf60c2ab4332442e4849f2851fc51a31, the `return true` statement which had come after the byte-comparing for loop was moved inside the for loop such that if the first byte compared was matching, this function would return true even if the rest of the bytes did not match.

This PR moves verifyEIP20's `return true` statement to after both checks have completed.