### PR TITLE
Bump package version for Truffle, Solhint & Solidty Coverage.

### DIFF
--- a/contracts/eip20/EIP20.sol
+++ b/contracts/eip20/EIP20.sol
@@ -40,7 +40,7 @@ contract EIP20 is EIP20Interface {
         require(balances[msg.sender] >= _value);
         balances[msg.sender] -= _value;
         balances[_to] += _value;
-        Transfer(msg.sender, _to, _value);
+        emit Transfer(msg.sender, _to, _value); //solhint-disable-line indent, no-unused-vars
         return true;
     }
 
@@ -52,7 +52,7 @@ contract EIP20 is EIP20Interface {
         if (allowance < MAX_UINT256) {
             allowed[_from][msg.sender] -= _value;
         }
-        Transfer(_from, _to, _value);
+        emit Transfer(_from, _to, _value); //solhint-disable-line indent, no-unused-vars
         return true;
     }
 
@@ -62,11 +62,11 @@ contract EIP20 is EIP20Interface {
 
     function approve(address _spender, uint256 _value) public returns (bool success) {
         allowed[msg.sender][_spender] = _value;
-        Approval(msg.sender, _spender, _value);
+        emit Approval(msg.sender, _spender, _value); //solhint-disable-line indent, no-unused-vars
         return true;
     }
 
     function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
         return allowed[_owner][_spender];
-    }   
+    }
 }

--- a/contracts/eip20/EIP20.sol
+++ b/contracts/eip20/EIP20.sol
@@ -3,7 +3,7 @@ Implements EIP20 token standard: https://github.com/ethereum/EIPs/blob/master/EI
 .*/
 
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 import "./EIP20Interface.sol";
 

--- a/contracts/eip20/EIP20Factory.sol
+++ b/contracts/eip20/EIP20Factory.sol
@@ -1,13 +1,13 @@
 import "./EIP20.sol";
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 contract EIP20Factory {
 
     mapping(address => address[]) public created;
     mapping(address => bool) public isEIP20; //verify without having to do a bytecode check.
-    bytes public EIP20ByteCode; // solhint-disable-line var-name-mixedcase  
+    bytes public EIP20ByteCode; // solhint-disable-line var-name-mixedcase
 
     function EIP20Factory() public {
         //upon creation of the factory, deploy a EIP20 (parameters are meaningless) and store the bytecode provably.
@@ -32,24 +32,24 @@ contract EIP20Factory {
         }
         return true;
     }
-    
-    function createEIP20(uint256 _initialAmount, string _name, uint8 _decimals, string _symbol) 
-        public 
+
+    function createEIP20(uint256 _initialAmount, string _name, uint8 _decimals, string _symbol)
+        public
     returns (address) {
 
         EIP20 newToken = (new EIP20(_initialAmount, _name, _decimals, _symbol));
         created[msg.sender].push(address(newToken));
         isEIP20[address(newToken)] = true;
         //the factory will own the created tokens. You must transfer them.
-        newToken.transfer(msg.sender, _initialAmount); 
+        newToken.transfer(msg.sender, _initialAmount);
         return address(newToken);
     }
 
-    //for now, keeping this internal. Ideally there should also be a live version of this that 
+    //for now, keeping this internal. Ideally there should also be a live version of this that
     // any contract can use, lib-style.
     //retrieves the bytecode at a specific address.
     function codeAt(address _addr) internal view returns (bytes outputCode) {
-        assembly { // solhint-disable-line no-inline-assembly   
+        assembly { // solhint-disable-line no-inline-assembly
             // retrieve the size of the code, this needs assembly
             let size := extcodesize(_addr)
             // allocate output byte array - this could also be done without assembly

--- a/contracts/eip20/EIP20Interface.sol
+++ b/contracts/eip20/EIP20Interface.sol
@@ -1,6 +1,6 @@
 // Abstract contract for the full ERC 20 Token standard
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 contract EIP20Interface {
@@ -44,7 +44,7 @@ contract EIP20Interface {
     /// @return Amount of remaining tokens allowed to spent
     function allowance(address _owner, address _spender) public view returns (uint256 remaining);
 
-    // solhint-disable-next-line no-simple-event-func-name  
-    event Transfer(address indexed _from, address indexed _to, uint256 _value); 
+    // solhint-disable-next-line no-simple-event-func-name
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/ConsenSys/Tokens#readme",
   "dependencies": {
-    "truffle": "4.0.6",
+    "truffle": "4.1.5",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "devDependencies": {
@@ -46,7 +46,7 @@
     "eslint-plugin-mocha": "4.11.0",
     "eslint-plugin-node": "5.1.0",
     "eslint-plugin-react": "7.5.1",
-    "solhint": "1.1.9",
-    "solidity-coverage": "0.4.9"
+    "solhint": "1.1.10",
+    "solidity-coverage": "0.4.15"
   }
 }


### PR DESCRIPTION
Bumping Truffle to version 4.1.5. This is primarily to get access to "emit" in Solidity 0.4.21. This is in prep for the ERC721 implementation that's coming.

This will fire warnings now about the the deprecation in EIP20 about 'emit', but Solhint hasn't updated yet to include this. https://github.com/protofire/solhint/issues/33

I bumped solhint & solidity coverage as well.

