### PR TITLE
EIP721

### DIFF
--- a/.solhintignore
+++ b/.solhintignore
@@ -1,0 +1,1 @@
+Migrations.sol

--- a/contracts/eip721/EIP721EnumerableInterface.sol
+++ b/contracts/eip721/EIP721EnumerableInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
 /// @title ERC-721 Non-Fungible Token Standard, optional enumeration extension

--- a/contracts/eip721/EIP721Interface.sol
+++ b/contracts/eip721/EIP721Interface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
 /// @title ERC-721 Non-Fungible Token Standard
@@ -30,12 +30,12 @@ interface EIP721Interface {
     ///  `_tokenId` is not a valid NFT. When transfer is complete, this function
     ///  checks if `_to` is a smart contract (code size > 0). If so, it calls
     ///  `onERC721Received` on `_to` and throws if the return value is not
-    ///  `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`.
+    ///  `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
-    /// @param _data Additional data with no specified format, sent in call to `_to`
-    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes _data) external payable;
+    /// @param data Additional data with no specified format, sent in call to `_to`
+    function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;
 
     /// @notice Transfers the ownership of an NFT from one address to another address
     /// @dev This works identically to the other function with an extra data parameter,
@@ -57,9 +57,9 @@ interface EIP721Interface {
     /// @param _tokenId The NFT to transfer
     function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
 
-    /// @notice Set or reaffirm the approved address for an NFT
+    /// @notice Change or reaffirm the approved address for an NFT.
     /// @dev The zero address indicates there is no approved address.
-    /// @dev Throws unless `msg.sender` is the current NFT owner, or an authorized
+    ///  Throws unless `msg.sender` is the current NFT owner, or an authorized
     ///  operator of the current owner.
     /// @param _approved The new approved NFT controller
     /// @param _tokenId The NFT to approve

--- a/contracts/eip721/EIP721MetadataInterface.sol
+++ b/contracts/eip721/EIP721MetadataInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
 /// @title ERC-721 Non-Fungible Token Standard, optional metadata extension

--- a/contracts/eip721/EIP721TokenReceiverInterface.sol
+++ b/contracts/eip721/EIP721TokenReceiverInterface.sol
@@ -1,18 +1,19 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 
-/// @dev Note: the ERC-165 identifier for this interface is 0xf0b9e5ba
+/// @dev Note: the ERC-165 identifier for this interface is 0x150b7a02.
 interface EIP721TokenReceiverInterface {
     /// @notice Handle the receipt of an NFT
-    /// @dev The ERC721 smart contract calls this function on the recipient
+    /// Note: the application will get the prior owner of the token
     ///  after a `transfer`. This function MAY throw to revert and reject the
-    ///  transfer.  Return of other than the magic value MUST result in the
+    ///  transfer. Return of other than the magic value MUST result in the
     ///  transaction being reverted.
     ///  Note: the contract address is always the message sender.
-    /// @param _from The sending address
-    /// @param _tokenId The NFT identifier which is being transfered
-    /// @param data Additional data with no specified format
-    /// @return `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`
+    /// @param _operator The address which called `safeTransferFrom` function
+    /// @param _from The address which previously owned the token
+    /// @param _tokenId The NFT identifier which is being transferred
+    /// @param _data Additional data with no specified format
+    /// @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
     ///  unless throwing
-    function onERC721Received(address _from, uint256 _tokenId, bytes data) external returns(bytes4);
+    function onERC721Received(address _operator, address _from, uint256 _tokenId, bytes _data) external returns(bytes4);
 }

--- a/contracts/eip721/TestEIP721Implementation.sol
+++ b/contracts/eip721/TestEIP721Implementation.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 import "./EIP721.sol";
 
 
@@ -12,7 +12,7 @@ contract TestEIP721Implementation is EIP721 {
     address public admin;
     uint256 public counter = 10;
 
-    function TestEIP721Implementation() public {
+    constructor() public {
         admin = msg.sender;
         name = "Test Collectible";
         symbol = "TCL";

--- a/contracts/eip721/TestNonStandardReceiver.sol
+++ b/contracts/eip721/TestNonStandardReceiver.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 
 // solhint-disable
 contract TestNonStandardReceiver {

--- a/contracts/eip721/TestReceiver.sol
+++ b/contracts/eip721/TestReceiver.sol
@@ -1,21 +1,22 @@
-pragma solidity ^0.4.21;
+pragma solidity ^0.4.24;
 import "./EIP721TokenReceiverInterface.sol";
 
 
-contract TestReceiver {
+contract TestReceiver is EIP721TokenReceiverInterface {
 
-    /// @notice Handle the receipt of an NFT
-    /// @dev The ERC721 smart contract calls this function on the recipient
-    ///  after a `transfer`. This function MAY throw to revert and reject the
-    ///  transfer. This function MUST use 50,000 gas or less. Return of other
-    ///  than the magic value MUST result in the transaction being reverted.
-    ///  Note: the contract address is always the message sender.
-    /// @param _from The sending address
-    /// @param _tokenId The NFT identifier which is being transfered
-    /// @param data Additional data with no specified format
-    /// @return `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`
-    ///  unless throwing
-    function onERC721Received(address _from, uint256 _tokenId, bytes data) public pure returns(bytes4) {
-        return 0xf0b9e5ba;
+  /// @notice Handle the receipt of an NFT
+  /// Note: the application will get the prior owner of the token
+  ///  after a `transfer`. This function MAY throw to revert and reject the
+  ///  transfer. Return of other than the magic value MUST result in the
+  ///  transaction being reverted.
+  ///  Note: the contract address is always the message sender.
+  /// @param _operator The address which called `safeTransferFrom` function
+  /// @param _from The address which previously owned the token
+  /// @param _tokenId The NFT identifier which is being transferred
+  /// @param _data Additional data with no specified format
+  /// @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+  ///  unless throwing
+    function onERC721Received(address _operator, address _from, uint256 _tokenId, bytes _data) external returns(bytes4) { //solhint-disable-line no-unused-vars
+        return bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"));
     }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/ConsenSys/Tokens#readme",
   "dependencies": {
-    "truffle": "4.1.7",
+    "truffle": "4.1.13",
     "truffle-hdwallet-provider": "0.0.3"
   },
   "devDependencies": {

--- a/test/eip721/eip721.js
+++ b/test/eip721/eip721.js
@@ -202,8 +202,8 @@ contract('TestEIP72Implementation', (accounts) => {
     await assertRevert(nft.ownerOf.call(12));
   });
 
-  // create 3 token to one user and then burn/remove all.
-  it('creation: create 5 tokens to one user and then burn/remove all.', async () => {
+  // create 5 tokens to one user and then burn/remove all, then create 5 more.
+  it('creation: create 5 tokens to one user, check state and then burn/remove all, then create 5 more, the burn from the other end.', async () => {
     await nft.createToken(accounts[1], { from: accounts[0] });
     await nft.createToken(accounts[1], { from: accounts[0] });
     await nft.createToken(accounts[1], { from: accounts[0] });
@@ -216,14 +216,50 @@ contract('TestEIP72Implementation', (accounts) => {
     await nft.burnToken(13, { from: accounts[1] });
     await nft.burnToken(14, { from: accounts[1] });
 
-    const totalSupply = await nft.totalSupply.call();
-    const balance = await nft.balanceOf.call(accounts[1]);
+    let totalSupply = await nft.totalSupply.call();
+    let balance = await nft.balanceOf.call(accounts[1]);
 
     assert.strictEqual(totalSupply.toString(), '0');
     assert.strictEqual(balance.toString(), '0');
     await assertRevert(nft.ownerOf.call(10));
     await assertRevert(nft.ownerOf.call(11));
     await assertRevert(nft.ownerOf.call(12));
+    await assertRevert(nft.ownerOf.call(13));
+    await assertRevert(nft.ownerOf.call(14));
+
+    await nft.createToken(accounts[1], { from: accounts[0] });
+    await nft.createToken(accounts[1], { from: accounts[0] });
+    await nft.createToken(accounts[1], { from: accounts[0] });
+    await nft.createToken(accounts[1], { from: accounts[0] });
+    await nft.createToken(accounts[1], { from: accounts[0] });
+
+    totalSupply = await nft.totalSupply.call();
+    balance = await nft.balanceOf.call(accounts[1]);
+
+    assert.strictEqual(totalSupply.toString(), '5');
+    assert.strictEqual(balance.toString(), '5');
+    assert.equal(await nft.ownerOf.call(15), accounts[1]);
+    assert.equal(await nft.ownerOf.call(16), accounts[1]);
+    assert.equal(await nft.ownerOf.call(17), accounts[1]);
+    assert.equal(await nft.ownerOf.call(18), accounts[1]);
+    assert.equal(await nft.ownerOf.call(19), accounts[1]);
+
+    await nft.burnToken(19, { from: accounts[1] });
+    await nft.burnToken(18, { from: accounts[1] });
+    await nft.burnToken(17, { from: accounts[1] });
+    await nft.burnToken(16, { from: accounts[1] });
+    await nft.burnToken(15, { from: accounts[1] });
+
+    totalSupply = await nft.totalSupply.call();
+    balance = await nft.balanceOf.call(accounts[1]);
+
+    assert.strictEqual(totalSupply.toString(), '0');
+    assert.strictEqual(balance.toString(), '0');
+    await assertRevert(nft.ownerOf.call(15));
+    await assertRevert(nft.ownerOf.call(16));
+    await assertRevert(nft.ownerOf.call(17));
+    await assertRevert(nft.ownerOf.call(18));
+    await assertRevert(nft.ownerOf.call(19));
   });
 
   it('transfer: transfer token successfully', async () => {


### PR DESCRIPTION
Hey all.

Here's a WIP of EIP721 along with an extensive test suite. https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md. 

EIP721 is non-fungible token standard of the Ethereum community. It contains several interfaces for implementing NFT: 

- A Base interface: This is all normal functionality (transferring, approving, etc).
- An Enumerable Interface: This interface makes it easier to enumerate over tokens [all or owned by specific owners].
- A Metadata Interface: Used for storing off-chain & on-chain information about the NFT.

The goal was to implement without too many dependencies into one specific EIP721 contract. It borrows from OpenZeppelin's implementation with various stylistic changes.

There's some things that I want to point out:

**Please Double Check Conformity to EIP721 standard**

Please help double check if I got all functions & interfaces & recommendations.

**Naming**

I spent a lot of time thinking about different naming of variables. Having to keep track of tokens using index arrays makes it complicated and sometimes cumbersome. Are the variable naming clear? If not, are there any other recommendations? I feel it could be even more clearer, but had trouble thinking up appropriate names. 

EIP721 itself has inconsistent naming: eg usage of ```approve``` to denote approving one owner per token ID vs ```setApprovalForAll``` which denotes setting a specific operator to be able to transfer & approve all tokens of a specific owner.

Other inconsistencies in the standard include:

- Mismatch of camelcase usage: eg tokenId vs tokenURI.
- Mismatch of dangling underscore: eg, last variable here does not have a dangling underscore ``` function safeTransferFrom(address _from, address _to, uint256 _tokenId, bytes data) external payable;```. Event logs also hate dangling underscores since eslint shouts about it.

Even though there are inconsistencies in the standard, I'd err on not changing an this, but the things we can change, I want more advice on this.

**No Function To Retrieve Token Arrays**

EIP721 does *not* specify a way to retrieve arrays of tokens. This seems like a shortsight? In the enumerable interface, it would've been nice to retrieve batches of arrays. Is this an extension we want to include perhaps? eg, return all tokens or return an owner's tokens. Otherwise, currently, you'll have to enumerate yourself with several eth_calls vs one eth_call.

**Default Payable?**

EIP721 by default sets transfer functions to add payable to transfer & approve functions. This does not seem the most secure to me. Should we perhaps think of forcing it to not have this by default?

**Blocking onERC721Received**

The standard specifies that receiver should not consumer more than 50000 gas. I find this an odd restriction. 

```This function MUST use 50,000 gas or less```.

What are thoughts on this?

**Revert Reason**

During the development of this EIP721, it became possible to add reasons for reverts (eg, using revert or require). Do we want to add this? I think it could help. > 0.4.22 of Solidity. I think for now, best to keep it simple, but in the future, perhaps upgrade to add in reasons. :)

**Naming Implementation**

The only unimplemented interface is naming & symbols. The reason being that's specified as ```external pure```. This means you can't even read state, so the only way to implement naming is to hardcode it in the function, which I feel is stylistically awkward. eg

```
function name() external pure returns (string _name) {
    return 'NFT name';
}
```

So, I changed to public as visibility specifier. This however does not change the interface signatures.

This PR also contains another bump of Truffle 4.1.7.

For now that it is it. I will update if more comes to mind.

Here's a pic of a puppy. NOTE: This is not a collectible. Do not attempt to buy it. ;)

![23930735040_c36423bd12_b](https://user-images.githubusercontent.com/716965/39270929-7b7408f8-48a5-11e8-9173-21e520f704aa.jpg)
