### PR TITLE
Add link to OpenZeppelin token contracts repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-We recommend using the thoroughly vetted OpenZeppelin token implementations. 
+We recommend using the thoroughly vetted [OpenZeppelin token](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/token) implementations. 
 
 # Tokens
 


### PR DESCRIPTION
I think it will be helpful if we add a link to the recommended OpenZeppelin token implementation.